### PR TITLE
Fix output being undefined after compilation error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ var config = require( "./config" )
   };
 
 var compile = function ( mimosaConfig, file, cb ) {
-  var output
+  var output = {}
     , error
     , mapText;
 


### PR DESCRIPTION
Trying to reference sourceMap when output was undefined would cause
mimosa to completely error out when there was a compilation error.
Initializing output to an empty object seems simpler than adding
more conditional logic to check output.

```
C:\projects\app\Content\node_modules\mimosa-react\src\index.js:23
  if ( output.sourceMap ) {
             ^
TypeError: Cannot read property 'sourceMap' of undefined
```
