### PR TITLE
Remove jsx pragma

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add `'react'` to your list of modules.  That's all!  Mimosa will install the mod
 
 ## Functionality
 
-This module will compile your React/JSX files.  It will also prepend the necessary `/** @jsx React.DOM */` comment so that you do not need to.
+This module will compile your React/JSX files.
 
 This module supports source maps and includes them during `mimosa watch` by default.  Source maps are disabled for `mimosa build`.
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,10 +10,6 @@ var compile = function ( mimosaConfig, file, cb ) {
     , error
     , mapText;
 
-  if ( file.inputFileText.indexOf( "@jsx React.DOM" ) === -1 ) {
-    file.inputFileText = "/** @jsx React.DOM */\n" + file.inputFileText;
-  }
-
   try {
     output = mimosaConfig.react.lib.transformWithDetails( file.inputFileText, mimosaConfig.react.options );
   } catch ( err ) {


### PR DESCRIPTION
As of v0.12 react no longer requires /*\* @jsx React.DOM */

http://facebook.github.io/react/blog/2014/10/16/react-v0.12-rc1.html#the-jsx-pragma-is-gone
